### PR TITLE
fix: type notation should be parenthesized in ModalFuncProps

### DIFF
--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -95,9 +95,9 @@ export interface ModalFuncProps {
   prefixCls?: string;
   class?: string;
   visible?: boolean;
-  title?: string | (() => VNodeTypes) | VNodeTypes;
+  title?: VNodeTypes | (() => VNodeTypes);
   closable?: boolean;
-  content?: string | (() => VNodeTypes) | VNodeTypes;
+  content?: VNodeTypes | (() => VNodeTypes);
   // TODO: find out exact types
   onOk?: (...args: any[]) => any;
   onCancel?: (...args: any[]) => any;
@@ -105,9 +105,9 @@ export interface ModalFuncProps {
   cancelButtonProps?: ButtonPropsType;
   centered?: boolean;
   width?: string | number;
-  okText?: string | (() => VNodeTypes) | VNodeTypes;
+  okText?: VNodeTypes | (() => VNodeTypes);
   okType?: LegacyButtonType;
-  cancelText?: string | (() => VNodeTypes) | VNodeTypes;
+  cancelText?: VNodeTypes | (() => VNodeTypes);
   icon?: (() => VNodeTypes) | VNodeTypes;
   /* Deprecated */
   iconType?: string;


### PR DESCRIPTION
@tangjinzhou  Sorry for #4664，我找到病根了

原本的类型定义是这样的：

```
title?: () => VNodeTypes | VNodeTypes;
```

这意味着 TS 认为 title 是一个函数，返回的是 VNodeTypes | VNodeTypes
也就是 VNodeTypes 本身

该错误可详见 Playground Reproduce：
https://www.typescriptlang.org/play?#code/C4TwDgpgBAglC8UDOwBOBLAdgcygHykwFcBbAIwlQG4AoUSKAIQSgAoBKBAPln1lpoAbCMChkAXExYByFBhzSB9aAGEWcAh278aQA

所以应该改为：

```
title: VNodeTypes | (() => VNodeTypes)
```

